### PR TITLE
wrap wp_cache_add_global_groups() in function_exists clause

### DIFF
--- a/wp-blog-meta.php
+++ b/wp-blog-meta.php
@@ -43,7 +43,9 @@ function _wp_blog_meta() {
 	}
 
 	// Register global cache group
-	wp_cache_add_global_groups( array( 'blog_meta' ) );
+	if ( function_exists( 'wp_cache_add_global_groups' ) ) {
+		wp_cache_add_global_groups( array( 'blog_meta' ) );
+	}
 }
 
 /**


### PR DESCRIPTION
WordPress Core usually wraps calls to `wp_cache_add_global_groups()` into a function_exists check, so we should probably do it here too in case some cache drop-in does not provide the function.
