### PR TITLE
Added update_blogmeta_cache and param

### DIFF
--- a/wp-blog-meta/includes/classes/class-wp-blog-meta-query.php
+++ b/wp-blog-meta/includes/classes/class-wp-blog-meta-query.php
@@ -58,6 +58,7 @@ class WP_Blog_Meta_Query {
 		add_action( 'parse_site_query', array( $this, 'parse_site_query' ) );
 		add_action( 'pre_get_sites',    array( $this, 'pre_get_sites'    ) );
 		add_action( 'sites_clauses',    array( $this, 'sites_clauses'    ), 10, 2 );
+		add_filter( 'the_sites',        array( $this, 'the_sites' ) );
 	}
 
 	/**
@@ -71,6 +72,7 @@ class WP_Blog_Meta_Query {
 
 		// Add empty meta_query
 		$site_query->query_var_defaults['meta_query'] = '';
+		$site_query->query_var_defaults['update_blog_meta_cache'] = false;
 
 		// Reparse the query vars with `meta_query` added
 		$site_query->query_vars = wp_parse_args( $site_query->query_vars, $site_query->query_var_defaults );
@@ -86,6 +88,9 @@ class WP_Blog_Meta_Query {
 	public function pre_get_sites( $site_query ) {
 		if ( ! isset( $site_query->query_var_defaults['meta_query'] ) ) {
 			$site_query->query_var_defaults['meta_query'] = '';
+		}
+		if ( ! isset( $site_query->query_var_defaults['update_blog_meta_cache'] ) ) {
+			$site_query->query_var_defaults['update_blog_meta_cache'] = false;
 		}
 	}
 
@@ -168,6 +173,18 @@ class WP_Blog_Meta_Query {
 
 		// Return maybe-replaced section of the database query
 		return $section;
+	}
+
+	/**
+	 * @since 1.1.0
+	 * @param $args
+	 */
+	public function the_sites( $args ){
+		$_sites = array_shift( $args );
+		$site_query = array_shift( $args );
+		if ( $site_query->query_var_defaults['update_blog_meta_cache']  ) {
+			update_blogmeta_cache( wp_list_pluck( $_sites, 'id' ) );
+		}
 	}
 }
 new WP_Blog_Meta_Query();

--- a/wp-blog-meta/includes/functions/metadata.php
+++ b/wp-blog-meta/includes/functions/metadata.php
@@ -75,3 +75,17 @@ function get_blog_meta( $id, $meta_key = '', $single = false ) {
 function update_blog_meta( $id, $meta_key, $meta_value, $prev_value = '' ) {
 	return update_metadata( 'blog', $id, $meta_key, $meta_value, $prev_value );
 }
+
+/**
+ * Updates metadata cache for list of blog IDs.
+ *
+ * Performs SQL query to retrieve all metadata for the blogs matching `$blog_ids` and stores them in the cache.
+ * Subsequent calls to `get_blog_meta()` will not need to query the database.
+ *
+ * @since 1.1.0
+ * @param array $blog_ids List of blog IDs.
+ * @return array|false Returns false if there is nothing to update. Returns an array of metadata on success.
+ */
+function update_blogmeta_cache( $blog_ids ) {
+	return update_meta_cache( 'blog', $blog_ids );
+}


### PR DESCRIPTION
Added new update_blogmeta_cache function. This brings us inline with core. 
Also added param in wp_site_query to prime blogmeta. By default it is off, which is different from core, but I good behaviour I believe. If you want to turn it on by default, you can always filter later. 