### PR TITLE
Cache clear meta

### DIFF
--- a/wp-blog-meta.php
+++ b/wp-blog-meta.php
@@ -36,6 +36,7 @@ function _wp_blog_meta() {
 	// Functions
 	require_once $plugin_path . 'includes/functions/metadata.php';
 	require_once $plugin_path . 'includes/functions/transients.php';
+	require_once $plugin_path . 'includes/functions/filters.php';
 
 	// Register database table
 	if ( empty( $GLOBALS['wpdb']->blogmeta ) ) {

--- a/wp-blog-meta/includes/functions/filters.php
+++ b/wp-blog-meta/includes/functions/filters.php
@@ -5,8 +5,6 @@
  * also clean blog meta
  *
  * @since 2.0.0
- *
- * @return string
  */
 function wp_blog_meta_clean_site_cache( $blog_id ) {
 	wp_cache_delete( $blog_id, 'blog_meta' );

--- a/wp-blog-meta/includes/functions/filters.php
+++ b/wp-blog-meta/includes/functions/filters.php
@@ -11,4 +11,4 @@
 function wp_blog_meta_clean_site_cache( $blog_id ) {
 	wp_cache_delete( $blog_id, 'blog_meta' );
 }
-add_action( 'clean_site_cache', $blog_id, 10, 1 );
+add_action( 'clean_site_cache', 'wp_blog_meta_clean_site_cache' , 10, 1 );

--- a/wp-blog-meta/includes/functions/filters.php
+++ b/wp-blog-meta/includes/functions/filters.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * When calling the clean_site_cache function, 
+ * also clean blog meta
+ *
+ * @since 2.0.0
+ *
+ * @return string
+ */
+function wp_blog_meta_clean_site_cache( $blog_id ) {
+	wp_cache_delete( $blog_id, 'blog_meta' );
+}
+add_action( 'clean_site_cache', $blog_id, 10, 1 );


### PR DESCRIPTION
To bring blog meta inline with other object types in wordpress, when calling site cache clear function, clear blog-meta too.